### PR TITLE
Bug: log incorrectly stated tables were not updated

### DIFF
--- a/src/mutation_table_updater/validate_and_update.py
+++ b/src/mutation_table_updater/validate_and_update.py
@@ -602,6 +602,7 @@ def update_tables(
                 copy_table(new_table_path, tables_dir)
             else:
                 copy_table(new_table_path, tables_dir)
+        return True
 
 
 def archive_cleanup(archive_dir: str) -> None:


### PR DESCRIPTION
Fix bug that didn't return True after updating tables, log incorrectly stated tables were not updated